### PR TITLE
feat(mobile): improve mobile UX experience

### DIFF
--- a/app/docs/layout.tsx
+++ b/app/docs/layout.tsx
@@ -2,6 +2,7 @@
 
 import { DocsSidebarNav } from "../../components/site/docs-sidebar-nav";
 import { DocsRightSidebar } from "../../components/site/docs-right-sidebar";
+import { MobileTocFab } from "../../components/site/mobile-toc-fab";
 
 interface DocsLayoutProps {
   children: React.ReactNode;
@@ -30,6 +31,9 @@ export default function DocsLayout({ children }: DocsLayoutProps) {
           </div>
         </aside>
       </div>
+
+      {/* Mobile TOC FAB - only visible on mobile/tablet */}
+      <MobileTocFab />
     </div>
   );
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -551,6 +551,113 @@ code {
   --sidebar-ring: hsl(0 0% 98%);
 }
 
+/* Mobile UX Utilities */
+.touch-manipulation {
+  touch-action: manipulation;
+}
+
+/* Prevent hover effects on touch devices */
+@media (hover: none) and (pointer: coarse) {
+  .hover-only:hover {
+    transform: none !important;
+    background: inherit !important;
+  }
+}
+
+/* Safe area insets for modern phones */
+.safe-area-inset-bottom {
+  padding-bottom: env(safe-area-inset-bottom, 0);
+}
+
+.safe-area-inset-top {
+  padding-top: env(safe-area-inset-top, 0);
+}
+
+/* Mobile input styles - prevent iOS zoom */
+@media (max-width: 768px) {
+  input[type="text"],
+  input[type="email"],
+  input[type="password"],
+  input[type="search"],
+  textarea,
+  select {
+    font-size: 16px !important;
+  }
+}
+
+/* Sheet animations */
+@keyframes slide-in-from-left {
+  from {
+    transform: translateX(-100%);
+  }
+  to {
+    transform: translateX(0);
+  }
+}
+
+@keyframes slide-in-from-right {
+  from {
+    transform: translateX(100%);
+  }
+  to {
+    transform: translateX(0);
+  }
+}
+
+@keyframes slide-in-from-top {
+  from {
+    transform: translateY(-100%);
+  }
+  to {
+    transform: translateY(0);
+  }
+}
+
+@keyframes slide-in-from-bottom {
+  from {
+    transform: translateY(100%);
+  }
+  to {
+    transform: translateY(0);
+  }
+}
+
+@keyframes slide-out-to-left {
+  from {
+    transform: translateX(0);
+  }
+  to {
+    transform: translateX(-100%);
+  }
+}
+
+@keyframes slide-out-to-right {
+  from {
+    transform: translateX(0);
+  }
+  to {
+    transform: translateX(100%);
+  }
+}
+
+@keyframes slide-out-to-top {
+  from {
+    transform: translateY(0);
+  }
+  to {
+    transform: translateY(-100%);
+  }
+}
+
+@keyframes slide-out-to-bottom {
+  from {
+    transform: translateY(0);
+  }
+  to {
+    transform: translateY(100%);
+  }
+}
+
 @layer base {
   * {
     @apply border-border outline-ring/50;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -88,8 +88,8 @@ export default function Home() {
             transition={{ duration: 0.5 }}
             className="space-y-8"
           >
-            <motion.h1 
-              className="text-5xl md:text-7xl lg:text-8xl font-extrabold tracking-tight leading-[1.1]"
+            <motion.h1
+              className="text-3xl sm:text-5xl md:text-6xl lg:text-7xl xl:text-8xl font-extrabold tracking-tight leading-[1.1]"
               initial={{ opacity: 0, y: 20 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.5, delay: 0.1 }}
@@ -112,8 +112,8 @@ export default function Home() {
               </span>
             </motion.h1>
             
-            <motion.p 
-              className="max-w-3xl mx-auto text-xl lg:text-2xl text-muted-foreground leading-relaxed"
+            <motion.p
+              className="max-w-3xl mx-auto text-base sm:text-lg md:text-xl lg:text-2xl text-muted-foreground leading-relaxed"
               initial={{ opacity: 0, y: 20 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.5, delay: 0.2 }}
@@ -145,8 +145,8 @@ export default function Home() {
               </Link>
             </motion.div>
 
-            <motion.div 
-              className="group relative flex items-center justify-between rounded-lg bg-muted/60 border-2 border-border/60 p-3 font-mono text-sm max-w-lg mx-auto mt-8 backdrop-blur-sm hover:bg-muted/80 hover:border-border/90 hover:shadow-md transition-all duration-300 cursor-pointer"
+            <motion.div
+              className="group relative flex items-center justify-between rounded-lg bg-muted/60 border-2 border-border/60 p-3 font-mono text-xs sm:text-sm max-w-lg mx-auto mt-8 backdrop-blur-sm hover:bg-muted/80 hover:border-border/90 hover:shadow-md transition-all duration-300 cursor-pointer touch-manipulation active:bg-muted/80"
               initial={{ opacity: 0, y: 20 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.5, delay: 0.4 }}

--- a/components/site/features-section.tsx
+++ b/components/site/features-section.tsx
@@ -118,7 +118,7 @@ export function FeaturesSection() {
         {/* Header */}
         <div className="text-center mb-12">
           <motion.h2
-            className="text-4xl md:text-6xl lg:text-7xl font-extrabold tracking-tight leading-[1.1] text-foreground mb-6"
+            className="text-2xl sm:text-4xl md:text-5xl lg:text-6xl font-extrabold tracking-tight leading-[1.1] text-foreground mb-6"
             variants={shouldReduceMotion ? {} : itemVariants}
           >
             Simple. Local.{" "}
@@ -138,7 +138,7 @@ export function FeaturesSection() {
           </motion.h2>
 
           <motion.p
-            className="text-xl md:text-2xl text-muted-foreground leading-relaxed max-w-3xl mx-auto"
+            className="text-base sm:text-lg md:text-xl lg:text-2xl text-muted-foreground leading-relaxed max-w-3xl mx-auto"
             variants={shouldReduceMotion ? {} : itemVariants}
           >
             Build modern charts with{" "}
@@ -147,9 +147,64 @@ export function FeaturesSection() {
           </motion.p>
         </div>
 
-        {/* Phantom Expansion Cards */}
+        {/* Mobile Cards - Vertical Stack */}
+        <div className="grid grid-cols-1 gap-6 mb-16 md:hidden">
+          {features.map((feature, index) => (
+            <motion.div
+              key={feature.title}
+              initial={{ opacity: 0, y: 20 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true }}
+              transition={{ delay: index * 0.1 }}
+            >
+              <div className="group relative flex flex-col overflow-hidden rounded-2xl border border-border/40 bg-card/95 backdrop-blur-xl shadow-lg">
+                {/* Media block */}
+                <div className="h-48 px-6 pt-6">
+                  <div className="relative flex h-full w-full items-center justify-center overflow-hidden rounded-xl border border-border/50 bg-muted/40">
+                    <div
+                      className="absolute inset-0 opacity-[0.12]"
+                      style={{
+                        backgroundImage: "radial-gradient(circle at 50% 35%, rgba(148, 163, 184, 0.18), transparent 65%)"
+                      }}
+                    />
+                    {feature.icon && (
+                      <feature.icon className="relative h-16 w-16 text-muted-foreground/70" weight="fill" />
+                    )}
+                  </div>
+                </div>
+
+                {/* Card Content */}
+                <div className="relative flex flex-col gap-3 px-6 py-6">
+                  <h3 className="text-lg font-semibold text-foreground tracking-tight">
+                    {feature.title}
+                  </h3>
+                  <p className="text-sm leading-relaxed text-muted-foreground">
+                    {feature.description}
+                  </p>
+
+                  {/* Code Snippet */}
+                  {feature.codeSnippet && (
+                    <div className="mt-2 rounded-xl border border-border/40 bg-muted/40 px-4 py-3 font-mono text-xs">
+                      <code className="text-foreground">
+                        <span className="text-muted-foreground">&lt;</span>
+                        <span className="text-primary font-semibold">BarChart</span>
+                        <span className="text-muted-foreground"> </span>
+                        <span className="text-foreground/80">data</span>
+                        <span className="text-muted-foreground">=&#123;</span>
+                        <span className="text-foreground/80">data</span>
+                        <span className="text-muted-foreground">&#125; /&gt;</span>
+                      </code>
+                    </div>
+                  )}
+                </div>
+              </div>
+            </motion.div>
+          ))}
+        </div>
+
+        {/* Desktop Cards - Phantom Expansion */}
         <div
-          className="relative min-h-[480px] mb-16 flex items-center justify-center"
+          className="relative min-h-[480px] mb-16 items-center justify-center hidden md:flex"
           style={{ perspective: "1500px" }}
         >
           <div className="relative w-full flex items-center justify-center">

--- a/components/site/mobile-docs-drawer.tsx
+++ b/components/site/mobile-docs-drawer.tsx
@@ -1,0 +1,271 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { motion, AnimatePresence } from "framer-motion";
+import { MagnifyingGlass, X, CaretRight, List } from "@phosphor-icons/react";
+
+import { cn } from "../../lib/utils";
+import { Logo } from "./logo";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "../ui/sheet";
+
+interface SidebarNavItem {
+  title: string;
+  href: string;
+  children?: SidebarNavItem[];
+  disabled?: boolean;
+}
+
+const sidebarNavItems: SidebarNavItem[] = [
+  {
+    title: "Getting Started",
+    href: "#",
+    children: [
+      { title: "Introduction", href: "/docs" },
+      { title: "Installation", href: "/docs/installation" },
+    ],
+  },
+  {
+    title: "Components",
+    href: "#",
+    children: [
+      { title: "Bar Chart", href: "/docs/components/bar-chart" },
+      { title: "Line Chart", href: "/docs/components/line-chart" },
+      { title: "Pie Chart", href: "/docs/components/pie-chart" },
+      { title: "Radar Chart", href: "/docs/components/radar-chart" },
+      { title: "Scatter Plot", href: "/docs/components/scatter-plot" },
+      { title: "Stacked Bar Chart", href: "/docs/components/stacked-bar-chart" },
+    ],
+  },
+];
+
+export function MobileDocsDrawer() {
+  const pathname = usePathname();
+  const [open, setOpen] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [expandedSections, setExpandedSections] = useState<string[]>(() => {
+    const expanded: string[] = ["Components"];
+    sidebarNavItems.forEach((section) => {
+      if (section.children?.some((child) => child.href === pathname)) {
+        if (!expanded.includes(section.title)) {
+          expanded.push(section.title);
+        }
+      }
+    });
+    return expanded;
+  });
+
+  const filteredItems = useMemo(() => {
+    if (!searchQuery.trim()) return sidebarNavItems;
+
+    const query = searchQuery.toLowerCase();
+    const filtered: SidebarNavItem[] = [];
+
+    sidebarNavItems.forEach((section) => {
+      if (section.title.toLowerCase().includes(query)) {
+        filtered.push(section);
+        return;
+      }
+
+      if (section.children) {
+        const matchingChildren = section.children.filter(
+          (child) =>
+            child.title.toLowerCase().includes(query) ||
+            child.href.toLowerCase().includes(query)
+        );
+
+        if (matchingChildren.length > 0) {
+          filtered.push({ ...section, children: matchingChildren });
+        }
+      }
+    });
+
+    return filtered;
+  }, [searchQuery]);
+
+  const toggleSection = (sectionTitle: string) => {
+    setExpandedSections((prev) =>
+      prev.includes(sectionTitle)
+        ? prev.filter((title) => title !== sectionTitle)
+        : [...prev, sectionTitle]
+    );
+  };
+
+  const handleLinkClick = () => {
+    setOpen(false);
+  };
+
+  return (
+    <Sheet open={open} onOpenChange={setOpen}>
+      <SheetTrigger asChild>
+        <button
+          className="inline-flex items-center justify-center rounded-md p-2.5 min-h-11 min-w-11 text-sm font-medium transition-colors hover:bg-muted hover:text-muted-foreground md:hidden touch-manipulation active:bg-muted/80"
+          aria-label="Open navigation menu"
+        >
+          <List size={24} aria-hidden="true" />
+        </button>
+      </SheetTrigger>
+      <SheetContent side="left" className="p-0 overflow-hidden">
+        <SheetHeader className="p-4 border-b">
+          <SheetTitle className="flex items-center gap-2">
+            <Logo size={20} />
+            <span>Mario Charts</span>
+          </SheetTitle>
+        </SheetHeader>
+
+        <div className="flex flex-col h-[calc(100%-65px)] overflow-hidden">
+          {/* Search */}
+          <div className="p-4 border-b">
+            <div className="relative">
+              <MagnifyingGlass
+                size={16}
+                className="absolute left-2.5 top-3 h-4 w-4 text-muted-foreground"
+              />
+              <input
+                type="text"
+                placeholder="Search..."
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                className={cn(
+                  "flex h-11 w-full rounded-md border border-input bg-transparent pl-8 pr-8 py-2 text-base shadow-sm transition-colors",
+                  "placeholder:text-muted-foreground",
+                  "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                )}
+              />
+              <AnimatePresence>
+                {searchQuery && (
+                  <motion.button
+                    initial={{ opacity: 0, scale: 0.8 }}
+                    animate={{ opacity: 1, scale: 1 }}
+                    exit={{ opacity: 0, scale: 0.8 }}
+                    onClick={() => setSearchQuery("")}
+                    className="absolute right-2.5 top-3 h-5 w-5 text-muted-foreground hover:text-foreground min-h-11 min-w-11 flex items-center justify-center -mr-2"
+                  >
+                    <X size={16} />
+                  </motion.button>
+                )}
+              </AnimatePresence>
+            </div>
+          </div>
+
+          {/* Navigation */}
+          <nav className="flex-1 overflow-y-auto p-4">
+            <div className="space-y-2">
+              {filteredItems.map((section) => {
+                const isExpanded = expandedSections.includes(section.title);
+                const hasChildren =
+                  section.children && section.children.length > 0;
+
+                return (
+                  <div key={section.title}>
+                    {hasChildren ? (
+                      <button
+                        onClick={() => toggleSection(section.title)}
+                        className={cn(
+                          "flex w-full items-center justify-between rounded-md px-3 py-2.5 min-h-11 text-sm font-medium transition-colors",
+                          "hover:bg-accent hover:text-accent-foreground",
+                          "active:bg-accent/80 touch-manipulation"
+                        )}
+                      >
+                        <span>{section.title}</span>
+                        <motion.div
+                          animate={{ rotate: isExpanded ? 90 : 0 }}
+                          transition={{ duration: 0.15, ease: "easeOut" }}
+                        >
+                          <CaretRight
+                            size={16}
+                            className="text-muted-foreground"
+                          />
+                        </motion.div>
+                      </button>
+                    ) : (
+                      <Link
+                        href={section.href}
+                        onClick={handleLinkClick}
+                        className={cn(
+                          "flex w-full items-center rounded-md px-3 py-2.5 min-h-11 text-sm font-medium",
+                          pathname === section.href
+                            ? "bg-accent text-accent-foreground"
+                            : "text-muted-foreground hover:bg-accent hover:text-accent-foreground",
+                          "active:bg-accent/80 touch-manipulation"
+                        )}
+                      >
+                        {section.title}
+                      </Link>
+                    )}
+
+                    <AnimatePresence initial={false}>
+                      {hasChildren && isExpanded && (
+                        <motion.div
+                          initial={{ height: 0, opacity: 0 }}
+                          animate={{ height: "auto", opacity: 1 }}
+                          exit={{ height: 0, opacity: 0 }}
+                          transition={{ duration: 0.2, ease: "easeOut" }}
+                          className="overflow-hidden"
+                        >
+                          <div className="ml-4 space-y-1 border-l border-border pl-4 pt-2">
+                            {section.children?.map((child) => (
+                              <Link
+                                key={child.href}
+                                href={child.href}
+                                onClick={handleLinkClick}
+                                className={cn(
+                                  "flex w-full items-center rounded-md px-3 py-2.5 min-h-11 text-sm transition-colors",
+                                  pathname === child.href
+                                    ? "bg-accent text-accent-foreground font-medium"
+                                    : "text-muted-foreground hover:bg-accent hover:text-accent-foreground",
+                                  child.disabled &&
+                                    "cursor-not-allowed opacity-60",
+                                  "active:bg-accent/80 touch-manipulation"
+                                )}
+                                aria-disabled={child.disabled}
+                              >
+                                {child.title}
+                                {child.disabled && (
+                                  <span className="ml-2 rounded-md bg-muted px-1.5 py-0.5 text-xs">
+                                    Soon
+                                  </span>
+                                )}
+                              </Link>
+                            ))}
+                          </div>
+                        </motion.div>
+                      )}
+                    </AnimatePresence>
+                  </div>
+                );
+              })}
+            </div>
+
+            {/* No Results */}
+            <AnimatePresence>
+              {searchQuery && filteredItems.length === 0 && (
+                <motion.div
+                  initial={{ opacity: 0, y: 10 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  exit={{ opacity: 0, y: 10 }}
+                  className="px-2 py-8 text-center text-sm text-muted-foreground"
+                >
+                  <p>No results found</p>
+                  <button
+                    onClick={() => setSearchQuery("")}
+                    className="mt-2 text-xs text-primary hover:underline touch-manipulation"
+                  >
+                    Clear search
+                  </button>
+                </motion.div>
+              )}
+            </AnimatePresence>
+          </nav>
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/components/site/mobile-toc-fab.tsx
+++ b/components/site/mobile-toc-fab.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { ListBullets } from "@phosphor-icons/react";
+import { motion } from "framer-motion";
+
+import { TableOfContents } from "./table-of-contents";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "../ui/sheet";
+
+export function MobileTocFab() {
+  return (
+    <Sheet>
+      <SheetTrigger asChild>
+        <motion.button
+          className="fixed bottom-6 right-6 z-40 h-14 w-14 rounded-full bg-primary text-primary-foreground shadow-lg flex items-center justify-center lg:hidden touch-manipulation"
+          whileHover={{ scale: 1.05 }}
+          whileTap={{ scale: 0.95 }}
+          aria-label="Open table of contents"
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: 0.5 }}
+        >
+          <ListBullets size={24} weight="bold" />
+        </motion.button>
+      </SheetTrigger>
+      <SheetContent side="bottom" className="h-[70vh] overflow-hidden">
+        <SheetHeader className="pb-4 border-b">
+          <SheetTitle>On this page</SheetTitle>
+        </SheetHeader>
+        <div className="overflow-y-auto h-[calc(100%-60px)] pt-4 pb-8">
+          <TableOfContents />
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/components/site/problem-section.tsx
+++ b/components/site/problem-section.tsx
@@ -43,7 +43,7 @@ export function ProblemSection() {
         animate="visible"
       >
         <motion.h2
-          className="text-4xl md:text-6xl lg:text-7xl font-extrabold tracking-tight leading-[1.1] text-foreground mb-6"
+          className="text-2xl sm:text-4xl md:text-5xl lg:text-6xl font-extrabold tracking-tight leading-[1.1] text-foreground mb-6"
           variants={shouldReduceMotion ? {} : itemVariants}
         >
           Building charts shouldn't be{" "}
@@ -62,14 +62,14 @@ export function ProblemSection() {
         </motion.h2>
 
         <motion.p
-          className="text-xl md:text-2xl text-muted-foreground leading-relaxed mb-4 max-w-3xl mx-auto"
+          className="text-base sm:text-lg md:text-xl lg:text-2xl text-muted-foreground leading-relaxed mb-4 max-w-3xl mx-auto"
           variants={shouldReduceMotion ? {} : itemVariants}
         >
           Most chart libraries are bloated, over-abstracted, or hard to customize.
         </motion.p>
 
         <motion.p
-          className="text-xl md:text-2xl text-foreground font-medium leading-relaxed max-w-3xl mx-auto"
+          className="text-base sm:text-lg md:text-xl lg:text-2xl text-foreground font-medium leading-relaxed max-w-3xl mx-auto"
           variants={shouldReduceMotion ? {} : itemVariants}
         >
           MarioCharts gives you{" "}

--- a/components/site/site-header.tsx
+++ b/components/site/site-header.tsx
@@ -9,6 +9,7 @@ import { useState } from "react";
 import { cn } from "../../lib/utils";
 import { ThemeToggle } from "./theme-toggle";
 import { Logo } from "./logo";
+import { MobileDocsDrawer } from "./mobile-docs-drawer";
 
 const navigation = [
   { name: "Docs", href: "/docs" },
@@ -68,37 +69,41 @@ export function SiteHeader() {
           </nav>
         </div>
 
-        {/* Mobile menu button */}
-        <motion.button
-          className="inline-flex items-center justify-center rounded-md p-2 text-sm font-medium transition-colors hover:bg-muted hover:text-muted-foreground md:hidden"
-          onClick={() => setIsMenuOpen(!isMenuOpen)}
-          whileTap={{ scale: 0.95 }}
-        >
-          <span className="sr-only">Open main menu</span>
-          <AnimatePresence mode="wait">
-            {isMenuOpen ? (
-              <motion.div
-                key="close"
-                initial={{ rotate: -90, opacity: 0 }}
-                animate={{ rotate: 0, opacity: 1 }}
-                exit={{ rotate: 90, opacity: 0 }}
-                transition={{ duration: 0.2 }}
-              >
-                <X size={24} aria-hidden="true" />
-              </motion.div>
-            ) : (
-              <motion.div
-                key="menu"
-                initial={{ rotate: 90, opacity: 0 }}
-                animate={{ rotate: 0, opacity: 1 }}
-                exit={{ rotate: -90, opacity: 0 }}
-                transition={{ duration: 0.2 }}
-              >
-                <List size={24} aria-hidden="true" />
-              </motion.div>
-            )}
-          </AnimatePresence>
-        </motion.button>
+        {/* Mobile menu - Docs Drawer for docs pages, regular menu for others */}
+        {pathname?.startsWith("/docs") ? (
+          <MobileDocsDrawer />
+        ) : (
+          <motion.button
+            className="inline-flex items-center justify-center rounded-md p-2.5 min-h-11 min-w-11 text-sm font-medium transition-colors hover:bg-muted hover:text-muted-foreground md:hidden touch-manipulation active:bg-muted/80"
+            onClick={() => setIsMenuOpen(!isMenuOpen)}
+            whileTap={{ scale: 0.95 }}
+          >
+            <span className="sr-only">Open main menu</span>
+            <AnimatePresence mode="wait">
+              {isMenuOpen ? (
+                <motion.div
+                  key="close"
+                  initial={{ rotate: -90, opacity: 0 }}
+                  animate={{ rotate: 0, opacity: 1 }}
+                  exit={{ rotate: 90, opacity: 0 }}
+                  transition={{ duration: 0.2 }}
+                >
+                  <X size={24} aria-hidden="true" />
+                </motion.div>
+              ) : (
+                <motion.div
+                  key="menu"
+                  initial={{ rotate: 90, opacity: 0 }}
+                  animate={{ rotate: 0, opacity: 1 }}
+                  exit={{ rotate: -90, opacity: 0 }}
+                  transition={{ duration: 0.2 }}
+                >
+                  <List size={24} aria-hidden="true" />
+                </motion.div>
+              )}
+            </AnimatePresence>
+          </motion.button>
+        )}
 
         {/* Mobile logo */}
         <div className="flex md:hidden">
@@ -132,9 +137,9 @@ export function SiteHeader() {
                 href="https://github.com/yuribodo/mariocharts"
                 target="_blank"
                 rel="noreferrer"
-                className="inline-flex items-center justify-center rounded-md p-2 text-sm font-medium transition-colors hover:bg-muted hover:text-muted-foreground"
+                className="inline-flex items-center justify-center rounded-md p-2.5 min-h-11 min-w-11 md:min-h-10 md:min-w-10 text-sm font-medium transition-colors hover:bg-muted hover:text-muted-foreground touch-manipulation active:bg-muted/80"
               >
-                <GithubLogo size={16} weight="fill" />
+                <GithubLogo size={20} weight="fill" />
                 <span className="sr-only">GitHub</span>
               </Link>
             </motion.div>
@@ -168,7 +173,7 @@ export function SiteHeader() {
                   <Link
                     href={item.href}
                     className={cn(
-                      "block rounded-md px-3 py-2 text-sm font-medium transition-colors hover:bg-muted hover:text-muted-foreground",
+                      "block rounded-md px-4 py-3 min-h-11 text-sm font-medium transition-colors hover:bg-muted hover:text-muted-foreground touch-manipulation active:bg-muted/80",
                       pathname?.startsWith(item.href)
                         ? "bg-muted text-muted-foreground"
                         : "text-foreground"

--- a/components/ui/sheet.tsx
+++ b/components/ui/sheet.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import * as React from "react";
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { X } from "@phosphor-icons/react";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "../../lib/utils";
+
+const Sheet = DialogPrimitive.Root;
+
+const SheetTrigger = DialogPrimitive.Trigger;
+
+const SheetClose = DialogPrimitive.Close;
+
+const SheetPortal = DialogPrimitive.Portal;
+
+const SheetOverlay = React.forwardRef<
+  React.ComponentRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    className={cn(
+      "fixed inset-0 z-50 bg-black/60 backdrop-blur-sm",
+      "data-[state=open]:animate-in data-[state=closed]:animate-out",
+      "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className
+    )}
+    {...props}
+    ref={ref}
+  />
+));
+SheetOverlay.displayName = DialogPrimitive.Overlay.displayName;
+
+const sheetVariants = cva(
+  "fixed z-50 gap-4 bg-background shadow-lg transition ease-in-out data-[state=closed]:duration-200 data-[state=open]:duration-300 data-[state=open]:animate-in data-[state=closed]:animate-out",
+  {
+    variants: {
+      side: {
+        top: "inset-x-0 top-0 border-b data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top",
+        bottom:
+          "inset-x-0 bottom-0 border-t rounded-t-2xl data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom",
+        left: "inset-y-0 left-0 h-full w-[85vw] max-w-[340px] border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left",
+        right:
+          "inset-y-0 right-0 h-full w-[85vw] max-w-[340px] border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right",
+      },
+    },
+    defaultVariants: {
+      side: "right",
+    },
+  }
+);
+
+interface SheetContentProps
+  extends React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>,
+    VariantProps<typeof sheetVariants> {
+  hideCloseButton?: boolean;
+}
+
+const SheetContent = React.forwardRef<
+  React.ComponentRef<typeof DialogPrimitive.Content>,
+  SheetContentProps
+>(({ side = "right", className, children, hideCloseButton, ...props }, ref) => (
+  <SheetPortal>
+    <SheetOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(sheetVariants({ side }), className)}
+      {...props}
+    >
+      {children}
+      {!hideCloseButton && (
+        <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary min-h-11 min-w-11 flex items-center justify-center touch-manipulation">
+          <X className="h-5 w-5" />
+          <span className="sr-only">Close</span>
+        </DialogPrimitive.Close>
+      )}
+    </DialogPrimitive.Content>
+  </SheetPortal>
+));
+SheetContent.displayName = DialogPrimitive.Content.displayName;
+
+const SheetHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col space-y-2 text-center sm:text-left",
+      className
+    )}
+    {...props}
+  />
+);
+SheetHeader.displayName = "SheetHeader";
+
+const SheetFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      className
+    )}
+    {...props}
+  />
+);
+SheetFooter.displayName = "SheetFooter";
+
+const SheetTitle = React.forwardRef<
+  React.ComponentRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn("text-lg font-semibold text-foreground", className)}
+    {...props}
+  />
+));
+SheetTitle.displayName = DialogPrimitive.Title.displayName;
+
+const SheetDescription = React.forwardRef<
+  React.ComponentRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+));
+SheetDescription.displayName = DialogPrimitive.Description.displayName;
+
+export {
+  Sheet,
+  SheetPortal,
+  SheetOverlay,
+  SheetTrigger,
+  SheetClose,
+  SheetContent,
+  SheetHeader,
+  SheetFooter,
+  SheetTitle,
+  SheetDescription,
+};


### PR DESCRIPTION
## Summary

- Add Sheet component (Radix Dialog) with left/right/top/bottom variants
- Add mobile navigation drawer for docs sidebar access
- Add floating TOC button with bottom sheet for quick navigation
- Improve touch targets to 44px minimum (WCAG AAA compliant)
- Fix typography scaling with proper mobile breakpoints
- Add mobile-first card layout for features section

## Changes

### New Components
- `components/ui/sheet.tsx` - Reusable Sheet/Drawer component
- `components/site/mobile-docs-drawer.tsx` - Docs navigation drawer
- `components/site/mobile-toc-fab.tsx` - TOC floating action button

### Improvements
- Touch targets increased from 36px to 44px
- Typography scales: `text-3xl sm:text-5xl md:text-6xl lg:text-7xl`
- Feature cards stack vertically on mobile
- Safe area insets for modern phones
- Touch-manipulation to prevent tap delay

## Test plan

- [ ] Test on iPhone SE (375px)
- [ ] Test on iPhone 14 (390px)
- [ ] Test on Android (412px)
- [ ] Test drawer opens/closes correctly
- [ ] Test TOC FAB opens bottom sheet
- [ ] Test navigation closes drawer on link click
- [ ] Verify touch targets are comfortable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added mobile navigation drawer for docs pages with search and section expansion.
  * Added floating action button for table of contents on mobile and tablet.
  * Introduced new sheet component for modal and drawer interactions.

* **Improvements**
  * Enhanced mobile layouts with responsive typography and mobile-first card arrangements.
  * Added touch-friendly interactions and safe-area utilities for improved mobile UX.
  * Implemented slide animations for sheet and drawer components.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->