### PR TITLE
fix: animate charts from origin axis instead of center

### DIFF
--- a/src/components/charts/funnel-chart/index.tsx
+++ b/src/components/charts/funnel-chart/index.tsx
@@ -235,7 +235,7 @@ function VerticalFunnel<T extends ChartDataItem>({
               strokeOpacity={0.5}
               className={cn("outline-none", onClick && "cursor-pointer")}
               style={{
-                transformOrigin: `${stage.cx}px ${centerY}px`,
+                transformOrigin: `${stage.cx}px ${stage.stageY}px`,
                 filter: isHovered ? `drop-shadow(0 0 6px ${stage.color})` : "none",
                 touchAction: "manipulation",
               }}

--- a/src/components/charts/heatmap/index.tsx
+++ b/src/components/charts/heatmap/index.tsx
@@ -475,7 +475,7 @@ function renderGrid<T extends ChartDataItem>({
             strokeOpacity={0.8}
             className="outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
             style={{ filter: isHovered ? `drop-shadow(0 0 4px ${cell.fillColor})` : "none" }}
-            initial={shouldAnimate ? { opacity: 0, scale: 0.5 } : { opacity: 0.9, scale: 1 }}
+            initial={shouldAnimate ? { opacity: 0, scale: 0.85 } : { opacity: 0.9, scale: 1 }}
             animate={{ opacity: isCross ? 0.3 : isHovered ? 1 : 0.9, scale: 1 }}
             transition={
               shouldAnimate
@@ -623,7 +623,7 @@ function renderRadial<T extends ChartDataItem>({
               transformOrigin: `${cx}px ${cy}px`,
               filter: isHovered ? `drop-shadow(0 0 4px ${cell.fillColor})` : "none",
             }}
-            initial={shouldAnimate ? { opacity: 0, scale: 0.3 } : { opacity: 0.85, scale: 1 }}
+            initial={shouldAnimate ? { opacity: 0, scale: 0.7 } : { opacity: 0.85, scale: 1 }}
             animate={{ opacity: isHovered ? 1 : 0.85, scale: 1 }}
             transition={
               shouldAnimate

--- a/src/components/charts/treemap-chart/index.tsx
+++ b/src/components/charts/treemap-chart/index.tsx
@@ -221,8 +221,8 @@ function TreeMapChartComponent({
           const showValue = rect.width >= MIN_LABEL_WIDTH && rect.height >= MIN_VALUE_HEIGHT;
 
           const motionProps = shouldAnimate ? {
-            initial: { scale: 0, opacity: 0 },
-            animate: { scale: 1, opacity: 1 },
+            initial: { scaleX: 0, scaleY: 0, opacity: 0 },
+            animate: { scaleX: 1, scaleY: 1, opacity: 1 },
             transition: {
               duration: 0.5,
               delay: i * 0.02,
@@ -230,7 +230,7 @@ function TreeMapChartComponent({
             },
           } : {};
 
-          const transformOrigin = `${rect.x + rect.width / 2}px ${rect.y + rect.height / 2}px`;
+          const transformOrigin = `${rect.x}px ${rect.y}px`;
 
           return (
             <motion.g


### PR DESCRIPTION
## Summary
- **Funnel (vertical):** changed `transformOrigin` from center of stage to top edge, so stages grow downward matching the natural funnel flow
- **TreeMap:** changed from `scale` (center) to `scaleX/scaleY` from top-left corner, creating a natural "fill-in" effect
- **Heatmap:** softened aggressive initial scale values — grid from `0.5` to `0.85`, calendar from `0.3` to `0.7`

Closes #24

## Test plan
- [ ] Open funnel chart (vertical variant) — stages should animate growing downward from their top edge
- [ ] Open funnel chart (horizontal variant) — should be unchanged (grows from left)
- [ ] Open treemap chart — rectangles should grow from top-left corner
- [ ] Open heatmap (grid variant) — cells should fade in with subtle scale, no aggressive pop
- [ ] Open heatmap (calendar variant) — circles should appear smoothly
- [ ] Open heatmap (stock variant) — should be unchanged
- [ ] Verify bar, line, pie, radar, gauge, scatter charts are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Refined animation behavior for funnel chart stages, heatmap cells, and treemap segments to enhance visual smoothness and consistency across chart components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->