### PR TITLE
feat(dashboard): Website Analytics example dashboard

### DIFF
--- a/app/examples/dashboards/analytics/analytics-dashboard-content.tsx
+++ b/app/examples/dashboards/analytics/analytics-dashboard-content.tsx
@@ -1,0 +1,286 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import { LineChart } from "@/src/components/charts/line-chart";
+import { PieChart } from "@/src/components/charts/pie-chart";
+import { HeatmapChart } from "@/src/components/charts/heatmap";
+import { StackedBarChart } from "@/src/components/charts/stacked-bar-chart";
+import { FunnelChart } from "@/src/components/charts/funnel-chart";
+
+import {
+  kpiData,
+  dailyTraffic,
+  trafficSources,
+  trafficHeatmap,
+  contentByDevice,
+  conversionFunnel,
+} from "./data";
+
+// ── Tiny SVG icons for KPIs ──────────────────────────────────────────
+const kpiIcons: Record<string, React.ReactNode> = {
+  eye: (
+    <svg width={18} height={18} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round">
+      <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
+      <circle cx="12" cy="12" r="3" />
+    </svg>
+  ),
+  users: (
+    <svg width={18} height={18} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round">
+      <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" />
+      <circle cx="9" cy="7" r="4" />
+      <path d="M23 21v-2a4 4 0 0 0-3-3.87" /><path d="M16 3.13a4 4 0 0 1 0 7.75" />
+    </svg>
+  ),
+  bounce: (
+    <svg width={18} height={18} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round">
+      <polyline points="7 17 17 7" />
+      <polyline points="17 17 17 7 7 7" />
+    </svg>
+  ),
+  clock: (
+    <svg width={18} height={18} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round">
+      <circle cx="12" cy="12" r="10" />
+      <polyline points="12 6 12 12 16 14" />
+    </svg>
+  ),
+};
+
+// ── KPI Card ─────────────────────────────────────────────────────────
+function KpiCard({
+  label,
+  value,
+  previousValue,
+  change,
+  context,
+  icon,
+}: {
+  label: string;
+  value: string;
+  previousValue: string;
+  change: number;
+  context: string;
+  icon: string;
+}) {
+  // For bounce rate, negative change is good
+  const isBounceRate = icon === "bounce";
+  const isPositive = isBounceRate ? change <= 0 : change >= 0;
+  return (
+    <div className="rounded-xl border bg-card p-4 shadow-sm">
+      <div className="flex items-center gap-2">
+        <div className="rounded-md bg-muted/60 p-1.5 text-muted-foreground">
+          {kpiIcons[icon]}
+        </div>
+        <span className="text-xs text-muted-foreground">{label}</span>
+      </div>
+      <p className="mt-2 text-2xl font-bold tracking-tight">{value}</p>
+      <div className="mt-1 flex items-center gap-2">
+        <span
+          className={cn(
+            "inline-flex items-center rounded-md px-1.5 py-0.5 text-xs font-semibold",
+            isPositive
+              ? "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400"
+              : "bg-red-500/10 text-red-600 dark:text-red-400"
+          )}
+        >
+          {change >= 0 ? "\u2191" : "\u2193"} {Math.abs(change)}%
+        </span>
+        <span className="text-xs text-muted-foreground">vs {previousValue}</span>
+      </div>
+      <p className="mt-1.5 text-xs text-muted-foreground/70">{context}</p>
+    </div>
+  );
+}
+
+// ── Chart Card with question-driven header ───────────────────────────
+function ChartCard({
+  question,
+  insight,
+  children,
+  className,
+}: {
+  question: string;
+  insight?: string;
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <div className={cn("rounded-xl border bg-card shadow-sm", className)}>
+      <div className="border-b px-5 py-3">
+        <h3 className="text-sm font-semibold text-foreground">{question}</h3>
+        {insight && (
+          <p className="mt-0.5 text-xs text-muted-foreground">{insight}</p>
+        )}
+      </div>
+      <div className="p-5">{children}</div>
+    </div>
+  );
+}
+
+// ── Section Header ───────────────────────────────────────────────────
+function SectionHeader({
+  title,
+  description,
+}: {
+  title: string;
+  description: string;
+}) {
+  return (
+    <div className="mb-4 mt-10 first:mt-0">
+      <h2 className="text-lg font-semibold tracking-tight">{title}</h2>
+      <p className="text-sm text-muted-foreground">{description}</p>
+    </div>
+  );
+}
+
+// ── Format helpers ───────────────────────────────────────────────────
+function formatNumber(value: number) {
+  if (value >= 1000000) return `${(value / 1000000).toFixed(1)}M`;
+  if (value >= 1000) return `${(value / 1000).toFixed(0)}K`;
+  return `${value}`;
+}
+
+// ── Dashboard ────────────────────────────────────────────────────────
+export function AnalyticsDashboardContent() {
+  const totalVisitors = trafficSources.reduce(
+    (sum, item) => sum + item.visitors,
+    0
+  );
+
+  return (
+    <div className="container mx-auto max-w-7xl select-text px-4 py-8">
+      {/* Header */}
+      <div className="mb-2">
+        <h1 className="text-2xl font-bold tracking-tight">
+          Website Analytics
+        </h1>
+        <p className="text-sm text-muted-foreground">
+          March 2026 &middot; compared to February 2026
+        </p>
+      </div>
+
+      {/* ── SECTION 1: Overview ───────────────────────────────────── */}
+      <SectionHeader
+        title="Overview"
+        description="Key metrics compared to last month"
+      />
+
+      <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
+        {kpiData.map((kpi) => (
+          <KpiCard
+            key={kpi.label}
+            label={kpi.label}
+            value={kpi.value}
+            previousValue={kpi.previousValue}
+            change={kpi.change}
+            context={kpi.context}
+            icon={kpi.icon}
+          />
+        ))}
+      </div>
+
+      {/* ── SECTION 2: Traffic Trends ─────────────────────────────── */}
+      <SectionHeader
+        title="Traffic Trends"
+        description="Daily visitor patterns and acquisition channels"
+      />
+
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-5">
+        <ChartCard
+          question="How is daily traffic trending?"
+          insight="Mid-week peaks with consistent weekend dips. Late March shows strong growth."
+          className="lg:col-span-3"
+        >
+          <LineChart
+            data={[...dailyTraffic]}
+            x="day"
+            y={["visitors", "pageViews"]}
+            colors={["#3b82f6", "#94a3b8"]}
+            height={280}
+            showArea
+            showAreaForSeries={[0]}
+            showGrid
+            curve="monotone"
+          />
+        </ChartCard>
+        <ChartCard
+          question="Where are visitors coming from?"
+          insight="Organic search drives 42% of traffic — SEO investment is paying off"
+          className="lg:col-span-2"
+        >
+          <PieChart
+            data={[...trafficSources]}
+            label="source"
+            value="visitors"
+            variant="donut"
+            colors={["#3b82f6", "#10b981", "#f59e0b", "#8b5cf6", "#ef4444"]}
+            height={280}
+            centerContent={
+              <div className="text-center">
+                <p className="text-2xl font-bold">{formatNumber(totalVisitors)}</p>
+                <p className="text-xs text-muted-foreground">total visitors</p>
+              </div>
+            }
+          />
+        </ChartCard>
+      </div>
+
+      {/* ── SECTION 3: Engagement Patterns ────────────────────────── */}
+      <SectionHeader
+        title="Engagement Patterns"
+        description="When users visit and what content they consume"
+      />
+
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-5">
+        <ChartCard
+          question="When are users most active?"
+          insight="Peak traffic: Tue-Thu, 10am-2pm. Weekends see 60% less traffic."
+          className="lg:col-span-3"
+        >
+          <HeatmapChart
+            data={[...trafficHeatmap]}
+            x="hour"
+            y="day"
+            value="visitors"
+            variant="grid"
+            colorScheme="blue"
+            height={300}
+          />
+        </ChartCard>
+        <ChartCard
+          question="What content do users engage with, by device?"
+          insight="Docs dominate on desktop. Product pages see more mobile traffic."
+          className="lg:col-span-2"
+        >
+          <StackedBarChart
+            data={[...contentByDevice]}
+            x="category"
+            y={["desktop", "mobile", "tablet"]}
+            colors={["#3b82f6", "#10b981", "#f59e0b"]}
+            height={300}
+            showLegend
+          />
+        </ChartCard>
+      </div>
+
+      {/* ── SECTION 4: Conversion Funnel ──────────────────────────── */}
+      <SectionHeader
+        title="Conversion Funnel"
+        description="User journey from first visit to paid subscription"
+      />
+
+      <ChartCard
+        question="Where do we lose users in the conversion journey?"
+        insight="Biggest drop-off: Visitor to Sign Up (86%). Onboarding to Active retains 59%."
+      >
+        <FunnelChart
+          data={[...conversionFunnel]}
+          label="stage"
+          value="count"
+          showConversionRates
+          height={340}
+          colors={["#3b82f6", "#6366f1", "#8b5cf6", "#a855f7", "#c084fc"]}
+        />
+      </ChartCard>
+    </div>
+  );
+}

--- a/app/examples/dashboards/analytics/data.ts
+++ b/app/examples/dashboards/analytics/data.ts
@@ -1,0 +1,125 @@
+// ── KPIs ──────────────────────────────────────────────────────────────
+// Each KPI answers: "How is this metric doing compared to last month?"
+export const kpiData = [
+  {
+    label: "Page Views",
+    value: "1.24M",
+    previousValue: "1.08M",
+    change: 15.3,
+    context: "Highest month since launch",
+    icon: "eye",
+  },
+  {
+    label: "Unique Visitors",
+    value: "342K",
+    previousValue: "314K",
+    change: 8.7,
+    context: "Organic search up 22%",
+    icon: "users",
+  },
+  {
+    label: "Bounce Rate",
+    value: "38.2%",
+    previousValue: "41.3%",
+    change: -3.1,
+    context: "New landing pages performing well",
+    icon: "bounce",
+  },
+  {
+    label: "Avg. Session Duration",
+    value: "4m 32s",
+    previousValue: "4m 02s",
+    change: 12.4,
+    context: "Docs revamp driving engagement",
+    icon: "clock",
+  },
+] as const;
+
+// ── Daily Traffic (Line) ─────────────────────────────────────────────
+// Answers: "What's the daily traffic trend? Any spikes or dips?"
+export const dailyTraffic = [
+  { day: "Mar 1", visitors: 10200, pageViews: 28500 },
+  { day: "Mar 2", visitors: 9800, pageViews: 26400 },
+  { day: "Mar 3", visitors: 8400, pageViews: 21800 },
+  { day: "Mar 4", visitors: 11500, pageViews: 31200 },
+  { day: "Mar 5", visitors: 12800, pageViews: 35600 },
+  { day: "Mar 6", visitors: 13200, pageViews: 37100 },
+  { day: "Mar 7", visitors: 12100, pageViews: 33800 },
+  { day: "Mar 8", visitors: 11400, pageViews: 30900 },
+  { day: "Mar 9", visitors: 9600, pageViews: 25200 },
+  { day: "Mar 10", visitors: 10800, pageViews: 29400 },
+  { day: "Mar 11", visitors: 13500, pageViews: 38200 },
+  { day: "Mar 12", visitors: 14200, pageViews: 40500 },
+  { day: "Mar 13", visitors: 13800, pageViews: 39100 },
+  { day: "Mar 14", visitors: 12900, pageViews: 36200 },
+  { day: "Mar 15", visitors: 11100, pageViews: 30100 },
+  { day: "Mar 16", visitors: 9200, pageViews: 24600 },
+  { day: "Mar 17", visitors: 11800, pageViews: 32400 },
+  { day: "Mar 18", visitors: 14800, pageViews: 42300 },
+  { day: "Mar 19", visitors: 15200, pageViews: 43800 },
+  { day: "Mar 20", visitors: 14600, pageViews: 41200 },
+  { day: "Mar 21", visitors: 13100, pageViews: 36800 },
+  { day: "Mar 22", visitors: 11800, pageViews: 32100 },
+  { day: "Mar 23", visitors: 9900, pageViews: 26800 },
+  { day: "Mar 24", visitors: 12400, pageViews: 34500 },
+  { day: "Mar 25", visitors: 15600, pageViews: 44800 },
+  { day: "Mar 26", visitors: 16100, pageViews: 46200 },
+  { day: "Mar 27", visitors: 15400, pageViews: 43900 },
+  { day: "Mar 28", visitors: 14200, pageViews: 39800 },
+  { day: "Mar 29", visitors: 12600, pageViews: 34900 },
+  { day: "Mar 30", visitors: 10400, pageViews: 28200 },
+] as const;
+
+// ── Traffic Sources (Pie) ────────────────────────────────────────────
+// Answers: "Where are visitors coming from?"
+export const trafficSources = [
+  { source: "Organic Search", visitors: 142800 },
+  { source: "Direct", visitors: 89200 },
+  { source: "Social Media", visitors: 52400 },
+  { source: "Referral", visitors: 38600 },
+  { source: "Email", visitors: 19000 },
+] as const;
+
+// ── Heatmap: Traffic by Day × Hour ──────────────────────────────────
+// Answers: "When are users most active?"
+const days = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"] as const;
+const hours = ["6am", "8am", "10am", "12pm", "2pm", "4pm", "6pm", "8pm", "10pm"] as const;
+
+// Realistic traffic pattern: weekday peaks at 10am-2pm, lower weekends
+const heatmapValues: Record<string, Record<string, number>> = {
+  Mon: { "6am": 120, "8am": 580, "10am": 1240, "12pm": 1380, "2pm": 1290, "4pm": 980, "6pm": 640, "8pm": 420, "10pm": 180 },
+  Tue: { "6am": 140, "8am": 620, "10am": 1350, "12pm": 1520, "2pm": 1410, "4pm": 1050, "6pm": 690, "8pm": 460, "10pm": 200 },
+  Wed: { "6am": 135, "8am": 610, "10am": 1380, "12pm": 1560, "2pm": 1440, "4pm": 1080, "6pm": 710, "8pm": 470, "10pm": 190 },
+  Thu: { "6am": 130, "8am": 590, "10am": 1310, "12pm": 1480, "2pm": 1360, "4pm": 1020, "6pm": 670, "8pm": 440, "10pm": 185 },
+  Fri: { "6am": 110, "8am": 520, "10am": 1180, "12pm": 1300, "2pm": 1150, "4pm": 860, "6pm": 540, "8pm": 380, "10pm": 210 },
+  Sat: { "6am": 60, "8am": 180, "10am": 420, "12pm": 520, "2pm": 480, "4pm": 390, "6pm": 340, "8pm": 460, "10pm": 280 },
+  Sun: { "6am": 50, "8am": 150, "10am": 380, "12pm": 460, "2pm": 440, "4pm": 360, "6pm": 310, "8pm": 490, "10pm": 260 },
+};
+
+export const trafficHeatmap = days.flatMap((day) =>
+  hours.map((hour) => ({
+    day,
+    hour,
+    visitors: heatmapValues[day]![hour]!,
+  }))
+);
+
+// ── Content by Device (Stacked Bar) ─────────────────────────────────
+// Answers: "What content do users engage with, and on which devices?"
+export const contentByDevice = [
+  { category: "Blog", desktop: 45200, mobile: 38400, tablet: 8600 },
+  { category: "Docs", desktop: 62100, mobile: 21800, tablet: 12400 },
+  { category: "Product", desktop: 38900, mobile: 42600, tablet: 6800 },
+  { category: "Landing", desktop: 28400, mobile: 35200, tablet: 5100 },
+  { category: "Pricing", desktop: 18600, mobile: 22100, tablet: 3800 },
+] as const;
+
+// ── Conversion Funnel ────────────────────────────────────────────────
+// Answers: "Where do we lose users in the conversion journey?"
+export const conversionFunnel = [
+  { stage: "Visitors", count: 342000 },
+  { stage: "Sign Up", count: 48200 },
+  { stage: "Onboarding", count: 31400 },
+  { stage: "Active User", count: 18600 },
+  { stage: "Paid Subscriber", count: 6200 },
+] as const;

--- a/app/examples/dashboards/analytics/page.tsx
+++ b/app/examples/dashboards/analytics/page.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from "next";
+import { AnalyticsDashboardContent } from "./analytics-dashboard-content";
+
+export const metadata: Metadata = {
+  title: "Website Analytics Dashboard — Mario Charts",
+  description:
+    "Interactive website analytics dashboard built with Mario Charts components.",
+};
+
+export default function AnalyticsDashboardPage() {
+  return <AnalyticsDashboardContent />;
+}


### PR DESCRIPTION
## Summary
- Adds a new **Website Analytics** dashboard example at `/examples/dashboards/analytics`
- Showcases 5 chart types not used in the existing Sales dashboard: **FunnelChart**, **HeatmapChart**, **PieChart** (donut), **StackedBarChart**, and **LineChart**
- Includes 4 sections: Overview KPIs, Traffic Trends, Engagement Patterns, and Conversion Funnel
- Follows the same patterns as the Sales dashboard (KpiCard, ChartCard, SectionHeader, question-driven headers)

## Test plan
- [ ] Navigate to `/examples/dashboards/analytics` and verify all 5 chart types render
- [ ] Check responsive layout on mobile (stacked) and desktop (side-by-side grids)
- [ ] Verify no TypeScript errors (`npx tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a comprehensive analytics dashboard providing Website Analytics insights
  * Displays KPI overview with key metrics and performance change indicators
  * Includes traffic trends visualization with daily visitor data and source breakdown
  * Features engagement patterns analysis with hourly heatmap data and device-based content distribution
  * Conversion funnel tracking shows user progression through conversion stages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->