### PR TITLE
fix(ssr): replace useLayoutEffect with useIsomorphicLayoutEffect

### DIFF
--- a/src/components/charts/pie-chart/index.tsx
+++ b/src/components/charts/pie-chart/index.tsx
@@ -1,9 +1,10 @@
 "use client";
 
 import * as React from "react";
-import { memo, useMemo, useState, useRef, useLayoutEffect } from "react";
+import { memo, useMemo, useState, useRef } from "react";
 import { motion } from "framer-motion";
 import { cn } from "../../../../lib/utils";
+import { useIsomorphicLayoutEffect } from "../../../../lib/hooks";
 
 // Types
 type ChartDataItem = Record<string, unknown>;
@@ -107,7 +108,7 @@ function useContainerDimensions() {
   const ref = useRef<HTMLDivElement>(null);
   const [width, setWidth] = useState(0);
 
-  useLayoutEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     const element = ref.current;
     if (!element) return;
 

--- a/src/components/charts/scatter-plot/index.tsx
+++ b/src/components/charts/scatter-plot/index.tsx
@@ -1,9 +1,10 @@
 "use client";
 
 import * as React from "react";
-import { memo, useMemo, useState, useRef, useLayoutEffect, useCallback } from "react";
+import { memo, useMemo, useState, useRef, useCallback } from "react";
 import { motion, AnimatePresence, useReducedMotion } from "framer-motion";
 import { cn } from "../../../../lib/utils";
+import { useIsomorphicLayoutEffect } from "../../../../lib/hooks";
 
 // Internal modules
 import type {
@@ -41,7 +42,7 @@ function useContainerDimensions() {
   const ref = useRef<HTMLDivElement>(null);
   const [width, setWidth] = useState(0);
 
-  useLayoutEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     const element = ref.current;
     if (!element) return;
 

--- a/src/components/charts/stacked-bar-chart/index.tsx
+++ b/src/components/charts/stacked-bar-chart/index.tsx
@@ -1,9 +1,10 @@
 "use client";
 
 import * as React from "react";
-import { memo, useMemo, useState, useRef, useLayoutEffect } from "react";
+import { memo, useMemo, useState, useRef } from "react";
 import { motion } from "framer-motion";
 import { cn } from "../../../../lib/utils";
+import { useIsomorphicLayoutEffect } from "../../../../lib/hooks";
 
 // Types
 type ChartDataItem = Record<string, unknown>;
@@ -89,7 +90,7 @@ function useContainerDimensions() {
   const ref = useRef<HTMLDivElement>(null);
   const [width, setWidth] = useState(0);
 
-  useLayoutEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     const element = ref.current;
     if (!element) return;
 


### PR DESCRIPTION
## Summary

- Replaces direct `useLayoutEffect` imports with `useIsomorphicLayoutEffect` in `pie-chart`, `scatter-plot`, and `stacked-bar-chart`
- Eliminates React SSR warnings: *"useLayoutEffect does nothing on the server"*
- Audited all remaining chart components — no other occurrences found

Closes #34

## Test plan

- [x] Build passes with no errors
- [x] Grep confirms zero remaining `useLayoutEffect` direct imports in `src/`
- [ ] Verify no SSR warnings in Next.js server logs during dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)