### PR TITLE
fix(registry): sync mario-charts.json and README with shipped charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ npx mario-charts@latest init
 npx mario-charts@latest add bar-chart kpi-card
 
 # Install peer dependencies
-npm install recharts date-fns framer-motion @radix-ui/react-tooltip
+npm install framer-motion
 ```
 
 ### Basic Usage
@@ -115,18 +115,21 @@ export function Dashboard() {
 ### Phase 1: Essential Core
 - ✅ **BarChart** - Responsive bar charts with filled/outline variants, vertical/horizontal orientations, and smooth animations
 - ✅ **LineChart** - Time series line charts
+- ✅ **AreaChart** - Area charts for cumulative data
 - ⏳ **KPICard** - Metric cards with sparklines
-- ⏳ **AreaChart** - Area charts for cumulative data
 
-### Phase 2: Fundamental Expansion  
-- ⏳ **PieChart/DonutChart** - Pie and donut charts
-- ⏳ **DataTable** - Data tables with filters and sorting
+### Phase 2: Fundamental Expansion
+- ✅ **PieChart/DonutChart** - Pie and donut charts
 - ✅ **StackedBarChart** - Multi-series bar charts
-- ⏳ **GaugeChart** - Progress and goal indicators
+- ✅ **GaugeChart** - Progress and goal indicators
+- ⏳ **DataTable** - Data tables with filters and sorting
 
 ### Phase 3: Advanced Features
-- ⏳ **ScatterPlot** - Correlation analysis charts
-- ⏳ **Heatmap** - Pattern recognition charts
+- ✅ **ScatterPlot** - Correlation analysis charts
+- ✅ **Heatmap** - Pattern recognition charts
+- ✅ **RadarChart** - Multi-axis comparison charts
+- ✅ **FunnelChart** - Conversion and drop-off charts
+- ✅ **TreeMapChart** - Hierarchical area charts
 - ⏳ **ProgressBar** - Custom progress indicators
 
 ## 🎨 Design System

--- a/mario-charts.json
+++ b/mario-charts.json
@@ -34,6 +34,7 @@
       "funnel-chart",
       "gauge-chart",
       "heatmap",
+      "stacked-bar-chart",
       "treemap-chart",
       "waterfall-chart"
     ],


### PR DESCRIPTION
## Summary

Housekeeping fixes found while auditing registry/docs consistency.

- **`mario-charts.json`** — add the missing `stacked-bar-chart` to `components.charts`. It shipped (component, docs, tests, nav) but was never registered in the config list.
- **`README.md`** — drop `recharts` from the peer-dependency install snippet. The distributed charts only import `framer-motion` (verified: `framer-motion` + `react` are the only external imports across `src/components/charts/**`). `recharts` is a docs-site-only dependency and shouldn't be in a consumer's install command.
- **`README.md`** — update the phase roadmap to reflect reality: Area, Pie, Gauge, Scatter, Heatmap, Radar, Funnel, and TreeMap have all shipped (they were still marked ⏳ or missing).

## Deliberately out of scope

- **Treemap URL slug** — the docs live at `/docs/components/treemap` while the component/registry name is `treemap-chart`. This is **intentional** (a shorter public URL) and **not a bug**: the page's install command already correctly says `add treemap-chart`, and there are no dead links. Renaming the public URL would be a needless SEO regression, so it's left as-is.
- **CLI fallback registry** — the deeper defect uncovered during this audit (the embedded fallback ships components with unresolved imports) is tracked separately in **#61**; it needs a dedicated, larger fix.

## Also

Closes the stale **#36** (custom tooltip renderer) — already shipped in merged PR #57.

## Notes

CI will run here once #59 (the CI pipeline) merges to `main`.
