### PR TITLE
fix(ci): pin Claude bot workflows to an active model

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -37,8 +37,9 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
-          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4.1)
-          # model: "claude-opus-4-1-20250805"
+          # Pin an active model. The action's old default (claude-sonnet-4-20250514)
+          # has been retired and now returns "404 not_found_error: model".
+          model: "claude-sonnet-5"
 
           # Direct prompt for automated review (no @claude mention needed)
           direct_prompt: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -40,9 +40,10 @@ jobs:
           additional_permissions: |
             actions: read
           
-          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4.1)
-          # model: "claude-opus-4-1-20250805"
-          
+          # Pin an active model. The action's old default (claude-sonnet-4-20250514)
+          # has been retired and now returns "404 not_found_error: model".
+          model: "claude-sonnet-5"
+
           # Optional: Customize the trigger phrase (default: @claude)
           # trigger_phrase: "/claude"
           


### PR DESCRIPTION
The **Claude Code Review** action has been failing on every PR:

> `API Error: 404 {"type":"not_found_error","message":"model: claude-sonnet-4-20250514"}`

The `anthropics/claude-code-action@beta` default model (`claude-sonnet-4-20250514`) has been **retired**, so every run 404s (see the failed run on #62).

**Fix:** pin both bot workflows to an active model.

- `.github/workflows/claude-code-review.yml` → `model: "claude-sonnet-5"`
- `.github/workflows/claude.yml` (the `@claude` bot) → same (it shared the same stale default)

YAML validated locally.